### PR TITLE
reorganized code to allow inclusion without execution

### DIFF
--- a/src/register.js
+++ b/src/register.js
@@ -1,0 +1,5 @@
+import { patchHttpClient, patchMocha } from './';
+
+
+patchHttpClient();
+patchMocha();

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,78 @@
+import chalk from 'chalk';
+
+/**
+ * Returns indent for pretty printing.
+ * @param  {integer} size - indent size in spaces
+ * @return {string} the indent string
+ */
+export function indent(size) {
+  let indentStr = '';
+  let _size = size;
+  while (_size > 0) {
+    indentStr += ' ';
+    _size--;
+  }
+  return indentStr;
+}
+
+/**
+ * Prints full requests URL seen in test.
+ */
+export function printTestRequest(testRequests) {
+  console.log(chalk.yellow(`${indent(6)} Live requests: `));
+
+  testRequests.forEach(request => {
+    console.log(chalk.yellow(`${indent(8)} * ${request}`));
+  });
+}
+
+/**
+ * Print requested hostnames summary.
+ */
+export function printHostnames(hostnames) {
+  console.log(chalk.yellow.bold(`${indent(2)} Hostnames requested: `));
+
+  if (Object.keys(hostnames).length === 0) {
+    console.log(chalk.yellow(`${indent(4)}none`));
+    return;
+  }
+
+  for (const key in hostnames) {
+    if (!hostnames[key]) return;
+    console.log(chalk.yellow(`${indent(4)}${key}: ${hostnames[key]}`));
+  }
+}
+
+/**
+ * Get the hostname from an HTTP options object.
+ * Supports multiple types of options.
+ * @param  {object} httpOptions
+ * @return {string} the hostname or "Unknown" if not found.
+ */
+export function getHostname(httpOptions) {
+  if (httpOptions.uri && httpOptions.uri.hostname) {
+    return httpOptions.uri.hostname;
+  } else if (httpOptions.hostname) {
+    return httpOptions.hostname;
+  } else if (httpOptions.host) {
+    return httpOptions.host;
+  }
+  return 'Unknown';
+}
+
+/**
+ * Get the href from an HTTP options objet.
+ * Supports multiple types of options.
+ * @param  {object} httpOptions
+ * @return {string} the hostname or "Unknown" if not found.
+ */
+export function getHref(httpOptions) {
+  if (httpOptions.uri && httpOptions.uri.href) {
+    return httpOptions.uri.href;
+  } else if (httpOptions.hostname && httpOptions.path) {
+    return httpOptions.hostname + httpOptions.path;
+  } else if (httpOptions.host && httpOptions.path) {
+    return httpOptions.host + httpOptions.path;
+  }
+  return 'Unknown';
+}

--- a/test/scenarios/localhost.js
+++ b/test/scenarios/localhost.js
@@ -9,6 +9,8 @@ describe('live requests', function() {
     server.listen(8585);
   });
 
+  after(server.close);
+
   it('passes', function() {
     assert(true);
   });

--- a/test/test.js
+++ b/test/test.js
@@ -4,7 +4,7 @@ import mocha from './utils/runner.js';
 
 describe('Mocha live detect', function() {
   describe('without live calls', function() {
-    mocha('./test/scenarios/no_live.js -R tap --require dist/index.js');
+    mocha('./test/scenarios/no_live.js -R tap --require dist/register.js');
 
     it('does not log any live request', function() {
       assert.include(res.out, 'Hostnames requested');
@@ -14,7 +14,7 @@ describe('Mocha live detect', function() {
   });
 
   describe('with local calls', function() {
-    mocha('./test/scenarios/localhost.js -R tap --require dist/index.js');
+    mocha('./test/scenarios/localhost.js -R tap --require dist/register.js');
 
     it('does not log any live request', function() {
       assert.include(res.out, 'Hostnames requested');
@@ -24,7 +24,7 @@ describe('Mocha live detect', function() {
   });
 
   describe('with live calls', function() {
-    mocha('./test/scenarios/live_requests.js -R tap --require dist/index.js');
+    mocha('./test/scenarios/live_requests.js -R tap --require dist/register.js');
 
     it('logs live call in test', function() {
       assert.include(res.out, 'Live requests');


### PR DESCRIPTION
Reorganized code to allow module inclusion without execution. To include and register in one-shot (like before), there's a separate file for that (`register.js`).

If you accept this PR, you'd need to update the readme file to the following:

``` shell
mocha -r mocha-http-detect/register
```
